### PR TITLE
Fix typo in PrimaryKey attribute name

### DIFF
--- a/src/load_tables_dataclass.py
+++ b/src/load_tables_dataclass.py
@@ -7,7 +7,7 @@ class BaseConfigModel(BaseModel):
 
 
 class PrimaryKey(BaseConfigModel):
-    autority: str = "manual"
+    authority: str = "manual"
     columns: list[str] | None = Field(default_factory=list)
 
 


### PR DESCRIPTION
[tady](https://linear.app/keboola/issue/DMD-875/connection-component-rename-typo-autority-authority) resim fix toho typo a az nasadime https://github.com/keboola/connection/pull/6645 tak se muze mergnout toto . Ten endpoint bude akceptovat oboji docasne, pak to i v connection prepnu na jen `authority`