### PR TITLE
Defensive fix: handle missing input mapping in keboola.app-data-gateway

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -41,7 +41,11 @@ class Component(ComponentBase):
         )
 
     def run(self):
-        self.storage_input = StorageInput(**self.configuration.config_data.get("storage", {}).get("input"))
+        # `storage` or `storage.input` can be missing / null when the configuration has no input
+        # mapping at all. Default to an empty mapping so this falls through to the UserException
+        # below instead of crashing with `argument after ** must be a mapping, not NoneType`.
+        storage_input = (self.configuration.config_data.get("storage") or {}).get("input") or {}
+        self.storage_input = StorageInput(**storage_input)
         if not self.storage_input.tables:
             raise UserException("No tables found. Please add one to the input mapping.")
 

--- a/tests/data/no_input_mapping/config.json
+++ b/tests/data/no_input_mapping/config.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "db": {
+      "workspaceId": 12345
+    },
+    "tableId": "in.c-main.users",
+    "dbName": "users_table",
+    "incremental": false,
+    "primaryKey": [],
+    "clone": false,
+    "items": []
+  },
+  "storage": {
+    "output": {
+      "tables": []
+    }
+  }
+}

--- a/tests/data/null_storage/config.json
+++ b/tests/data/null_storage/config.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "db": {
+      "workspaceId": 12345
+    },
+    "tableId": "in.c-main.users",
+    "dbName": "users_table",
+    "incremental": false,
+    "primaryKey": [],
+    "clone": false,
+    "items": []
+  },
+  "storage": null
+}

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -4,6 +4,8 @@ import os
 import json
 from freezegun import freeze_time
 
+from keboola.component.exceptions import UserException
+
 from component import Component, parse_last_run_to_timestamp
 
 
@@ -222,6 +224,50 @@ class TestComponent(unittest.TestCase):
             config["parameters"]["tableId"] = original_table_id
             with open(config_path, "w") as f:
                 json.dump(config, f)
+
+    @freeze_time("2024-01-15 10:00:00")
+    @mock.patch("component.Client")
+    @mock.patch.dict(
+        os.environ,
+        {
+            "KBC_DATADIR": "./tests/data/no_input_mapping",
+            "KBC_STACKID": "connection.keboola.com",
+            "KBC_TOKEN": "test-token",
+            "KBC_CONFIGID": "12345",
+        },
+    )
+    def test_missing_input_mapping_raises_user_exception(self, mock_client):
+        """A config whose storage block has no `input` fails as a UserException, not an internal error"""
+        mock_client_instance = mock_client.return_value
+
+        comp = Component()
+        with self.assertRaises(UserException) as ctx:
+            comp.run()
+
+        self.assertIn("input mapping", str(ctx.exception))
+        mock_client_instance.workspaces.load_tables.assert_not_called()
+
+    @freeze_time("2024-01-15 10:00:00")
+    @mock.patch("component.Client")
+    @mock.patch.dict(
+        os.environ,
+        {
+            "KBC_DATADIR": "./tests/data/null_storage",
+            "KBC_STACKID": "connection.keboola.com",
+            "KBC_TOKEN": "test-token",
+            "KBC_CONFIGID": "12345",
+        },
+    )
+    def test_null_storage_raises_user_exception(self, mock_client):
+        """A config with a null `storage` block fails as a UserException, not an internal error"""
+        mock_client_instance = mock_client.return_value
+
+        comp = Component()
+        with self.assertRaises(UserException) as ctx:
+            comp.run()
+
+        self.assertIn("input mapping", str(ctx.exception))
+        mock_client_instance.workspaces.load_tables.assert_not_called()
 
     # INCREMENTAL LOAD TESTS
 


### PR DESCRIPTION
## Summary

Adds defensive handling for an unhandled `TypeError` observed in production. No change to the component's behaviour on inputs that already worked.

## Root cause

`TypeError: StorageInput() argument after ** must be a mapping, not NoneType` at `src/component.py:44`.

`run()` unpacked the input mapping with `StorageInput(**config_data.get("storage", {}).get("input"))`. When a configuration has no input mapping, `storage.input` is absent (or null), `.get("input")` returns `None`, and `**None` raises before the component's own guard on the very next line — `raise UserException("No tables found. Please add one to the input mapping.")` — ever gets a chance to run. The job therefore died with an opaque internal error (exit 2) instead of the clear user error the component already had written for exactly this situation. A null `storage` block hits the same wall one step earlier.

Classified as **user-actionable (exit 2 -> exit 1)**; 1 occurrence in the alert window.

## Fix

Default a missing/null `storage` or `storage.input` to an empty mapping, so the run falls through to the component's existing `No tables found. Please add one to the input mapping.` `UserException`. Only `None`/absent values are substituted — any configuration that already supplied a `storage.input` mapping takes the identical code path it did before.

## Behaviour impact: none — defensive-only

- Happy path unchanged; no outputs, transforms, schema, or config semantics touched. `(... or {}).get("input") or {}` substitutes only for falsy/absent values, and a non-empty mapping is truthy.
- The job still fails on a genuine misconfiguration — it now raises the component's own `UserException` (exit 1, actionable message) instead of an opaque internal error (exit 2). Nothing is swallowed into a success: a run with no input mapping cannot load anything, and it still fails.
- Existing tests pass unchanged (no assertions modified or deleted), and regression tests now cover both newly-handled shapes.

## Evidence

Datadog: https://app.datadoghq.eu/monitors/97152903?group=%40job.componentId%3Akeboola.app-data-gateway

## Tests

Existing suite green and unchanged (17 -> 19 passed) via the repo's CI command, `python -m unittest discover`. Two regression tests added:

- `test_missing_input_mapping_raises_user_exception` — `storage` present, no `input` key (the exact production shape)
- `test_null_storage_raises_user_exception` — `storage: null`

Both fail on `main` (`TypeError` / `AttributeError`) and pass with the fix. `flake8 src --config=flake8.cfg` clean.